### PR TITLE
Add basic bra–ket utilities in Julia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# test
-codex test
+# Braket Example
+
+This repository contains a simple implementation of bra-ket calculations in Julia without relying on external packages. The `braket.jl` script defines a small module for creating kets, computing inner and outer products, and forming tensor products.
+
+## Files
+- `braket.jl` – module with core functions
+- `test_braket.jl` – example usage script
+
+## Usage
+Run the example script with Julia:
+
+```bash
+julia test_braket.jl
+```
+
+The script prints inner products, outer products, and tensor products for a pair of example kets.

--- a/braket.jl
+++ b/braket.jl
@@ -1,0 +1,43 @@
+module Braket
+
+export Ket, bra, inner, outer, tensor
+
+"""A ket represented by a vector of complex numbers"""
+struct Ket
+    data::Vector{ComplexF64}
+end
+
+"""Return the bra (conjugate transpose) of a ket"""
+function bra(k::Ket)
+    conj.(k.data)
+end
+
+"""Compute inner product between two kets"""
+function inner(k1::Ket, k2::Ket)
+    sum(conj.(k1.data) .* k2.data)
+end
+
+"""Compute inner product between a bra vector and a ket"""
+function inner(bra::Vector{ComplexF64}, k::Ket)
+    sum(bra .* k.data)
+end
+
+"""Compute outer product of two kets"""
+function outer(k1::Ket, k2::Ket)
+    k1.data * (conj.(k2.data))'
+end
+
+"""Tensor product (Kronecker) of two kets"""
+function tensor(k1::Ket, k2::Ket)
+    n1 = length(k1.data)
+    n2 = length(k2.data)
+    result = Vector{ComplexF64}(undef, n1 * n2)
+    for i in 1:n1
+        for j in 1:n2
+            result[(i - 1) * n2 + j] = k1.data[i] * k2.data[j]
+        end
+    end
+    Ket(result)
+end
+
+end # module

--- a/test_braket.jl
+++ b/test_braket.jl
@@ -1,0 +1,17 @@
+include("braket.jl")
+using .Braket
+
+# Define some sample kets
+a = Ket([1.0 + 0im, 0.0 + 0im])
+b = Ket([0.0 + 0im, 1.0 + 0im])
+
+println("inner(a,a) = ", inner(a,a))
+println("inner(a,b) = ", inner(a,b))
+
+out = outer(a,b)
+println("outer(a,b) = ")
+println(out)
+
+tens = tensor(a,b)
+println("tensor(a,b) = ", tens.data)
+


### PR DESCRIPTION
## Summary
- add `braket.jl` module with simple bra–ket inner/outer product utilities
- provide `test_braket.jl` example script
- document usage in `README.md`

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687db0d42b74832a93ae5ac2f5d2e39c